### PR TITLE
Petit souci dans la pagination de la page d'acceuil

### DIFF
--- a/src/Sdz/BlogBundle/Controller/BlogController.php
+++ b/src/Sdz/BlogBundle/Controller/BlogController.php
@@ -34,12 +34,20 @@ class BlogController extends Controller
                      ->getManager()
                      ->getRepository('SdzBlogBundle:Article')
                      ->getArticles($nbParPage, $page);
-
+    //Si il n'y a qu'une seule page de résultat alors le resultat
+    //de ceil(count($articles)/$nbParPage) vaut 0
+    if(ceil(count($articles)/$nbParPage) == 0){
+        $nbrpage = 1;//Or il doit toujours y avoir au moins une page
+    }
+    else{
+        $nbrpage = ceil(count($articles)/$nbParPage);
+    }
+    
     // On passe le tout à la vue
     return $this->render('SdzBlogBundle:Blog:index.html.twig', array(
       'articles' => $articles,
       'page'     => $page,
-      'nb_page'  => ceil(count($articles) / $nbParPage)
+      'nb_page'  => $nbrpage
     ));
   }
 


### PR DESCRIPTION
Cette méthode fonctionne correctement à par dans le cas ou il n'y à encore aucun article. En effet si aucun article n'est retrourné par la méthode getArticles() alors la pagination devrait affiché  seulement la page 1. Hors dans ce cas elle affiche deux pages "1 - 0 " dans cet ordre. 
Pour que l'affichage de la pagination reste donc cohérent il faudrait faire un petit test sur le "ceil(count($articles)/3)" et dans le cas ou il est égale à 0 mettre une varible $nbPage à 1 et sinon à la valeur de "ceil(count($articles)/3)".
