### PR TITLE
Update ArticleType.php

### DIFF
--- a/src/Sdz/BlogBundle/Form/ArticleType.php
+++ b/src/Sdz/BlogBundle/Form/ArticleType.php
@@ -34,7 +34,7 @@ class ArticleType extends AbstractType
           'type'         => new ArticleCompetenceType(),
           'allow_add'    => true,
           'allow_delete' => true,
-      	//'mapped'       => false,
+      	  'mapped'       => false,
           'by_reference' => false,
           'required'     => false
       ))


### PR DESCRIPTION
Permet de ne pas avoir l'erreur
FatalErrorException: Error: Maximum function nesting level of '100' reached, aborting! in SdzBlog/app/cache/dev/classes.php line 6026
Quand on édite un article avec une compétence lié à l'article
