### PR TITLE
Correctif UserBundle (deprecated entity classes)

### DIFF
--- a/src/Sdz/UserBundle/Entity/User.php
+++ b/src/Sdz/UserBundle/Entity/User.php
@@ -2,7 +2,7 @@
 
 namespace Sdz\UserBundle\Entity;
 
-use FOS\UserBundle\Entity\User as BaseUser;
+use FOS\UserBundle\Model\User as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
 
 /**


### PR DESCRIPTION
Correctif de UserBundle afin de prendre en compte les modifications liée à la suppression des classes entity de FOSUserBundle.

Voir notamment https://github.com/FriendsOfSymfony/FOSUserBundle/commit/1e4689ecd688d0129ee33ecb83e3d030e94e9cc8
